### PR TITLE
docs: harden repo presentation and licensing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @fjoelnr @ha-llm-bot

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 fjoelnr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,159 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object
+code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work.
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source or
+Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License,
+each Contributor hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section) patent
+license to make, have made, use, offer to sell, sell, import, and otherwise
+transfer the Work, where such license applies only to those patent claims
+licensable by such Contributor that are necessarily infringed by their
+Contribution(s) alone or by combination of their Contribution(s) with the Work
+to which such Contribution(s) was submitted. If You institute patent litigation
+against any entity (including a cross-claim or counterclaim in a lawsuit)
+alleging that the Work or a Contribution incorporated within the Work
+constitutes direct or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate as of the date
+such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from the
+Source form of the Work, excluding those notices that do not pertain to any part
+of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then
+any Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without any
+additional terms or conditions. Notwithstanding the above, nothing herein shall
+supersede or modify the terms of any separate license agreement you may have
+executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in
+tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to in
+writing, shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability to
+use the Work (including but not limited to damages for loss of goodwill, work
+stoppage, computer failure or malfunction, or any and all other commercial
+damages or losses), even if such Contributor has been advised of the possibility
+of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or
+Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such
+obligations, You may act only on Your own behalf and on Your sole responsibility,
+not on behalf of any other Contributor, and only if You agree to indemnify,
+defend, and hold each Contributor harmless for any liability incurred by, or
+claims asserted against, such Contributor by reason of your accepting any such
+warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -1,78 +1,125 @@
-# WoW AI Companion (Coach)
+# WoW AI Companion
 
-Repositories were built for humans.  
-ANR makes them readable for agents.
+A ToS-compliant World of Warcraft AI copilot for guidance, review, and second-screen recommendations.
 
-➡ **Schnellstart:** siehe [`docs/QUICKSTART_DE.md`](docs/QUICKSTART_DE.md)  
-Weitere Doku:
-- Setup Windows (WoW): [`docs/SETUP_WINDOWS_WOW.md`](docs/SETUP_WINDOWS_WOW.md)
-- Setup Docker-Host: [`docs/SETUP_SERVER_DOCKER.md`](docs/SETUP_SERVER_DOCKER.md)
-- ENV Variablen: [`docs/ENV_VARS.md`](docs/ENV_VARS.md)
-- CI/Branch-Protection: [`docs/CI_GITHUB.md`](docs/CI_GITHUB.md)
-- Git-Workflow: [`docs/WORKFLOW_GIT.md`](docs/WORKFLOW_GIT.md)
-- Troubleshooting: [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md)
+This project is intentionally **not** a bot and **not** an automation layer. It collects player context, runs external analysis, and returns tips to the player without sending input back into the game client.
 
-Ein **ToS-konformer** World of Warcraft Copilot: gibt **Tipps & Hinweise**, automatisiert **nichts**.
-- Addon (Lua) sammelt Daten & zeigt Empfehlungen.
-- Externe Analyse (Docker, Linux) via MCP-Server + LLM (lokal über Ollama oder API).
-- Fokus v1: Erkundung/Quests/Sammelziele/Rares. Kampf-Coach später.
+## What It Does
+
+- WoW addon for snapshot export and in-game tip display
+- external Python watcher for SavedVariables and combat log ingestion
+- MCP server for tool-style analysis and tip generation
+- local-first LLM runtime via Ollama, with optional API fallback
+
+## What It Does Not Do
+
+- no input automation
+- no rotation botting
+- no movement, combat, or interaction execution
+- no hidden network logic inside the addon
+
+## Current Focus
+
+Version focus is currently on:
+
+- exploration and quest support
+- collecting, rares, and route hints
+- data export and second-screen analysis
+
+Combat coaching is a later stage and remains guidance-only.
+
+## Repository Layout
+
+```text
+addon/            WoW addon source (Lua)
+agents/           planner / retriever / validator / coach logic
+mcp-server/       MCP and analysis server
+external/python/  watcher runtime and prompts
+docs/             setup, architecture, privacy, troubleshooting
+tools/            local helper scripts
+.agents/          ANR context, workflows, skills, guardrails
+```
+
+## Quick Start
+
+1. Clone the repository.
+2. Copy `addon/AICompanion` into your WoW AddOns directory.
+3. Start the external stack with Docker.
+4. Export a game snapshot in WoW.
+5. Review generated recommendations in game.
+
+English quickstart:
+- [docs/QUICKSTART.md](docs/QUICKSTART.md)
+
+German quickstart:
+- [docs/QUICKSTART_DE.md](docs/QUICKSTART_DE.md)
+
+Supporting setup docs:
+- [docs/SETUP_WINDOWS_WOW.md](docs/SETUP_WINDOWS_WOW.md)
+- [docs/SETUP_SERVER_DOCKER.md](docs/SETUP_SERVER_DOCKER.md)
+- [docs/ENV_VARS.md](docs/ENV_VARS.md)
+- [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)
+
+## Architecture
+
+High-level flow:
+
+1. The addon exports structured state from the game client.
+2. The watcher observes SavedVariables and combat logs outside the client.
+3. The MCP server enriches and validates the data.
+4. The LLM layer generates recommendations.
+5. The addon renders tips back to the player.
+
+Further reading:
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- [docs/PRIVACY.md](docs/PRIVACY.md)
+- [docs/STATUS.md](docs/STATUS.md)
+
+## Safety and ToS Position
+
+This repository is designed around a strict constraint:
+
+- the addon observes and displays
+- the external stack analyzes
+- the player decides and acts
+
+No gameplay automation is part of the intended product scope.
 
 ## ANR Context Layer
 
-Dieses Repository ist ein praktisches Beispiel dafuer, wie ein bestehendes Projekt auf ANR migriert werden kann.
+This repository also serves as a practical ANR-style example for agent-readable project structure.
 
-Die Grundidee ist dieselbe wie im ANR-Standard:
+- global context: [AGENTS.md](AGENTS.md)
+- repository index: [.agents/context-index.md](.agents/context-index.md)
+- local context: `AGENT.md` files near high-risk areas
+- reusable workflows, skills, and guardrails in `.agents/`
 
-- `AGENTS.md` gibt globalen Kontext
-- lokale `AGENT.md` Dateien liegen nahe an risikoreichen Bereichen
-- Skills kapseln wiederverwendbare Denkweisen
-- Workflows beschreiben, wie gearbeitet wird
-- Guardrails halten gefaehrliche Aenderungen kontrolliert
+The goal is not documentation volume. The goal is making the repository understandable to both humans and coding agents.
 
-Das Ziel ist nicht mehr Text.
-Das Ziel ist, dass ein Agent im Repo arbeitet wie ein Engineer mit Projekterfahrung statt wie ein Chatbot ohne Orientierung.
+## Status
 
-- Global context: `AGENTS.md`
-- Repository map: `.agents/context-index.md`
-- Local context: `addon/AGENT.md`, `agents/AGENT.md`, `mcp-server/AGENT.md`, `external/python/AGENT.md`, `docs/AGENT.md`, `tools/AGENT.md`
-- Skills: `.agents/skills/`
-- Workflows: `.agents/workflows/`
-- Guardrails: `.agents/guardrails/`
-- Manifest: `anr.yaml`
+The project is in active early-stage development.
 
-## How ANR Fits This Repository
+- addon, watcher, and MCP structure exist
+- Docker workflow exists
+- documentation baseline exists
+- product polish, setup hardening, and clearer user-facing onboarding are still in progress
 
-```text
-AI Agent
-   |
-AGENTS.md
-   |
-.agents/context-index.md
-   |
-+----------------+----------------+----------------+
-|                |                |                |
-addon/AGENT.md   agents/AGENT.md  mcp-server/AGENT.md
-|                |                |
-+----------------+----------------+----------------+
-                 |
-      .agents/workflows / skills / guardrails
-```
-
-Hier liegt der praktische Nutzen:
-ein Agent kann die WoW-Addon-Logik, die Python-Agenten und den MCP-Server als getrennte Zonen mit eigenen Regeln verstehen.
-
-## Schnellstart (kurz)
-1) Addon nach `_retail_/Interface/AddOns/AICompanion/` kopieren.  
-2) Docker starten (`docker-compose.yml`) → `ollama`, `mcp`, `watcher`.  
-3) Im Spiel: `/aicoach export` → extern Analyse → `/reload` → Tippspanel.
-
-Siehe `docs/ARCHITECTURE.md` für Details.
+See [docs/STATUS.md](docs/STATUS.md) and [docs/ROADMAP.md](docs/ROADMAP.md).
 
 ## Branching
-- `main` = Releases (tags)
-- `develop` = stabile Entwicklungsbasis
-- `feature/*` = PR → `develop`; Release via PR `develop → main` + Tag
 
-## Lizenzen
-- Addon (Lua): MIT (siehe `LICENSE`)
-- External/MCP: Apache-2.0 (siehe `LICENSE-APACHE`)
+- `develop` is the default integration branch
+- feature work goes to `feature/*` branches and merges into `develop`
+- `main` is the release branch and is promoted from `develop`
+
+See [docs/WORKFLOW_GIT.md](docs/WORKFLOW_GIT.md).
+
+## Licensing
+
+This repository uses split licensing by component:
+
+- addon and repository-level project material: MIT, see [LICENSE](LICENSE)
+- external runtime and MCP-oriented service code: Apache-2.0, see [LICENSE-APACHE](LICENSE-APACHE)
+
+When contributing, keep that separation explicit.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,0 +1,44 @@
+# Status
+
+## Product Status
+
+`wow-ai-companion` is an active prototype-stage project.
+
+The core idea is already visible:
+
+- the addon can collect and display guidance
+- the external runtime can ingest exported context
+- an MCP/LLM pipeline can generate recommendations
+
+The project is not yet polished as a user-facing package and still needs setup hardening, clearer onboarding, and broader validation.
+
+## What Works
+
+- addon structure and command flow
+- Docker-based local stack
+- external watcher/runtime base
+- MCP-based analysis pattern
+- ANR repository scaffolding
+
+## What Still Needs Work
+
+- stronger end-user README and setup flow
+- better validation of common WoW installation paths
+- clearer separation of stable vs experimental features
+- more implementation-level tests
+- more polished examples and screenshots
+
+## Safety Boundary
+
+This repository is guidance-only by design.
+
+- no gameplay automation
+- no hidden input execution
+- no addon-side network logic
+
+## Next Improvement Areas
+
+- setup documentation quality
+- architecture consistency across addon, agents, and MCP server
+- stronger examples for common use cases
+- release hardening for public consumption


### PR DESCRIPTION
## Summary\n- replace placeholder license files with real MIT and Apache 2.0 texts\n- rewrite the root README to be more product-facing and operator-friendly\n- add CODEOWNERS and a compact status document\n\n## Testing\n- git diff --check\n