### PR TITLE
ci: only run releases for version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 on:
   push:
-    branches: [ main ]
     tags:
       - 'v*.*.*'
 jobs:


### PR DESCRIPTION
## Summary\n- stop the release workflow from running on every push to main\n- keep release creation limited to version tags where GitHub Releases is valid\n\n## Testing\n- workflow logic review\n