### PR TITLE
promote: develop to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 on:
   push:
-    branches: [ main ]
     tags:
       - 'v*.*.*'
 jobs:


### PR DESCRIPTION
## Summary\n- promote the release workflow fix from develop to main\n- keep release creation limited to version tags\n